### PR TITLE
Change class_name to PascalCase

### DIFF
--- a/addons/anti-cheating/ac_dict.gd
+++ b/addons/anti-cheating/ac_dict.gd
@@ -1,5 +1,5 @@
 extends RefCounted
-class_name ac_dict
+class_name ACDict
 
 # The number of times interference data is generated; the higher the value, the lower the performance, but the better the effect.
 var disturb: int = 0
@@ -7,12 +7,12 @@ var disturb: int = 0
 # private
 var _pool: Dictionary
 
-func set_value(key: String, value: ac_value):
+func set_value(key: String, value: ACValue):
 	_pool[key] = value
 	# Generate interference data
 	_do_disturb.call_deferred(value)
 	
-func get_value(key: String, default_value: ac_value = ac_value.new()) -> ac_value:
+func get_value(key: String, default_value: ACValue = ACValue.new()) -> ACValue:
 	if _pool.has(key):
 		return _pool[key]
 	return default_value
@@ -32,7 +32,7 @@ func clear():
 func is_empty() -> bool:
 	return _pool.is_empty()
 	
-func _do_disturb(value: ac_value):
+func _do_disturb(value: ACValue):
 	if not is_instance_valid(self):
 		return
 	for i in disturb:

--- a/addons/anti-cheating/ac_node.gd
+++ b/addons/anti-cheating/ac_node.gd
@@ -1,5 +1,5 @@
 extends Node
-class_name ac_node
+class_name ACNode
 
 # The number of times interference data is generated; the higher the value, the lower the performance, but the better the effect.
 var disturb: int = 0:
@@ -8,16 +8,16 @@ var disturb: int = 0:
 	get:
 		return _dict.disturb
 
-var _dict: ac_dict = ac_dict.new()
+var _dict: ACDict = ACDict.new()
 
 func _init(parent: Node = null):
 	if parent:
 		parent.add_child(self)
 	
-func set_value(key: String, value: ac_value):
+func set_value(key: String, value: ACValue):
 	_dict.set_value(key, value)
 	
-func get_value(key: String, default_value: ac_value = ac_value.new()) -> ac_value:
+func get_value(key: String, default_value: ACValue = ACValue.new()) -> ACValue:
 	return _dict.get_value(key, default_value)
 	
 func has(key: String) -> bool:

--- a/addons/anti-cheating/ac_validator.gd
+++ b/addons/anti-cheating/ac_validator.gd
@@ -1,8 +1,8 @@
 extends RefCounted
-class_name ac_validator
+class_name ACValidator
 
 # override
-func with(value) -> ac_validator:
+func with(value) -> ACValidator:
 	# Save the original data
 	return self
 	

--- a/addons/anti-cheating/float_validator.gd
+++ b/addons/anti-cheating/float_validator.gd
@@ -1,4 +1,4 @@
-extends ac_validator
+extends ACValidator
 
 var _s0: float = 0
 var _s1: float = 0
@@ -6,7 +6,7 @@ var _1: float = 0
 var _2: float = 0
 var _3: int = 0
 
-func with(value: float) -> ac_validator:
+func with(value: float) -> ACValidator:
 	_3 = Time.get_unix_time_from_system()
 	_s1 = randf_range(1.5, 2)
 	_s0 = value * -_s1

--- a/addons/anti-cheating/float_value.gd
+++ b/addons/anti-cheating/float_value.gd
@@ -1,8 +1,8 @@
-extends ac_value
-class_name ac_float
+extends ACValue
+class_name ACFloat
 
 var _value: float
-var _validator: ac_validator
+var _validator: ACValidator
 	
 func _init(v: float = 0) -> void:
 	_value = v
@@ -14,10 +14,10 @@ func value():
 	return _value
 	
 # override
-func _get_validator() -> ac_validator:
+func _get_validator() -> ACValidator:
 	return preload("float_validator.gd").new()
 	
 # override
-func duplicate() -> ac_value:
-	return ac_float.new(_value)
+func duplicate() -> ACValue:
+	return ACFloat.new(_value)
 	

--- a/addons/anti-cheating/int_validator.gd
+++ b/addons/anti-cheating/int_validator.gd
@@ -1,11 +1,11 @@
-extends ac_validator
+extends ACValidator
 
 var _0: int = 0
 var _1: int = 0
 var _2: int = 0
 var _3: int = 0
 
-func with(value: int) -> ac_validator:
+func with(value: int) -> ACValidator:
 	_2 = Time.get_unix_time_from_system()
 	_0 = value - _2
 	_1 = value + _2

--- a/addons/anti-cheating/int_value.gd
+++ b/addons/anti-cheating/int_value.gd
@@ -1,8 +1,8 @@
-extends ac_value
-class_name ac_int
+extends ACValue
+class_name ACInt
 
 var _value: int
-var _validator: ac_validator
+var _validator: ACValidator
 	
 func _init(v: int = 0) -> void:
 	_value = v
@@ -14,10 +14,10 @@ func value() -> int:
 	return _value
 	
 # override
-func _get_validator() -> ac_validator:
+func _get_validator() -> ACValidator:
 	return preload("int_validator.gd").new()
 	
 # override
-func duplicate() -> ac_value:
-	return ac_int.new(_value)
+func duplicate() -> ACValue:
+	return ACInt.new(_value)
 	

--- a/addons/anti-cheating/value.gd
+++ b/addons/anti-cheating/value.gd
@@ -1,7 +1,7 @@
 extends RefCounted
-class_name ac_value
+class_name ACValue
 
-func get_validator() -> ac_validator:
+func get_validator() -> ACValidator:
 	return _get_validator()
 	
 # override
@@ -9,10 +9,10 @@ func value():
 	return 0
 	
 # override
-func duplicate() -> ac_value:
-	return ac_value.new()
+func duplicate() -> ACValue:
+	return ACValue.new()
 	
 # override
-func _get_validator() -> ac_validator:
-	return ac_validator.new()
+func _get_validator() -> ACValidator:
+	return ACValidator.new()
 	

--- a/scene/main.gd
+++ b/scene/main.gd
@@ -3,13 +3,13 @@ extends Control
 @onready var _test1 = $CenterContainer/VBoxContainer/Test1
 @onready var _test2 = $CenterContainer/VBoxContainer/Test2
 
-var _pool: ac_node = acGlobalPool
+var _pool: ACNode = acGlobalPool
 
 var _acvalue: int:	# anti-cheating int: Cannot easily search and modify from memory.
 	set(v):
-		_pool.set_value("namespace:value", ac_int.new(v))
+		_pool.set_value("namespace:value", ACInt.new(v))
 	get:
-		return _pool.get_value("namespace:value", ac_int.new(0)).value()
+		return _pool.get_value("namespace:value", ACInt.new(0)).value()
 	
 var _value: int # normal int: Can easily search and modify from memory.
 


### PR DESCRIPTION
Change `class_name` style to PascalCase to match [Godot naming convention](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#naming-conventions)